### PR TITLE
Zero pad single digit digital air channels

### DIFF
--- a/sharp_aquos_rc/tv.py
+++ b/sharp_aquos_rc/tv.py
@@ -293,7 +293,7 @@ class TV(object):
         """
         if opt1 == '?':
             return self._send_command('DA2P', opt1)
-        return self._send_command('DA2P', (opt1 * 100) + opt2)
+        return self._send_command('DA2P', '{:02d}{:02d}'.format(opt1, opt2))
 
     def digital_channel_cable(self, opt1='?', opt2=1):
         """


### PR DESCRIPTION
I found that digital air channels less than 10 needed to be zero padded to two digits in order for my LC70LE660U to accept them.