### PR TITLE
Added teletext support and fixed readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sharp_aquos_rc
 
-### Control Sharp Aquos SmartTVs with Python
+## Control Sharp Aquos SmartTVs with Python
 
 Based on the API for "Remote Control App" defined on pages 8-3 through 8-8 in the [sharp-user-manual].
 
@@ -12,7 +12,9 @@ Based on the API for "Remote Control App" defined on pages 8-3 through 8-8 in th
 
 3) Set Login/Pass
 
-### Installation
+## Installation and basic instructions
+
+Installation via pip:
 
     pip install sharp_aquos_rc
 
@@ -48,17 +50,17 @@ True
 True
 ```
 
-### Documentation
+## Documentation
 
 Full Documentation is available through pydoc
 
     pydoc sharp_aquos_rc
 
-### LICENSE
+## LICENSE
 
 MIT
 
-### TODO/Contribute
+## TODO/Contribute
 
 Contributions and Pull Requests always welcome.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 ## Control Sharp Aquos SmartTVs with Python
 
-Based on the API for "Remote Control App" defined on pages 8-3 through 8-8 in the [sharp-user-manual].
+Based on the API for "Remote Control App" defined on:
+
+- pages 8-3 (101) through 8-8 (106) in the
+  [sharp user manual](http://files.sharpusa.com/Downloads/ForHome/HomeEntertainment/LCDTVs/Manuals/2014_TV_OM.pdf)
+- pages 58 through 59 in another
+  [sharp user manual](http://www.sharp.co.uk/cps/rde/xbcr/documents/documents/om/11_lcd-tv/LC40-46LE830E-RU-LE831E-RU_OM_GB.pdf)
 
 ### To enable API on your TV
 
@@ -37,18 +42,16 @@ as an option to the class constructor. For example:
 
 ### Examples
 
-```
->>> import sharp_aquos_rc
->>>
->>> tv = sharp_aquos_rc.TV('192.168.1.5', 10002, 'admin', 'password')
->>> 
->>> tv.power() # Returns 1 if TV is on and 0 if TV is off
-1
->>> tv.power(0) # Turn the TV off
-True
->>> tv.input(2) # Set the TV to HDMI Input 2
-True
-```
+    >>> import sharp_aquos_rc
+    >>>
+    >>> tv = sharp_aquos_rc.TV('192.168.1.5', 10002, 'admin', 'password')
+    >>>
+    >>> tv.power() # Returns 1 if TV is on and 0 if TV is off
+    1
+    >>> tv.power(0) # Turn the TV off
+    True
+    >>> tv.input('HDMI 2') # Set the TV to HDMI Input 2
+    True
 
 ## Documentation
 
@@ -68,7 +71,5 @@ Currently on the TODO list:
 - Remote Button Functionality
 - Unit Tests
 - Error Checking and Input Validation
-
-[sharp-user-manual](http://files.sharpusa.com/Downloads/ForHome/HomeEntertainment/LCDTVs/Manuals/2014_TV_OM.pdf)
-
-
+- Better timeouts for sequential operations so that the sent 
+  commands don't get ignored.

--- a/README.md
+++ b/README.md
@@ -1,21 +1,11 @@
 # sharp_aquos_rc
 
-## Control Sharp Aquos SmartTVs with Python
+Control Sharp Aquos SmartTVs with Python
 
-Based on the API for "Remote Control App" defined on:
+## Quick start
 
-- pages 8-3 (101) through 8-8 (106) in the
-  [sharp user manual](http://files.sharpusa.com/Downloads/ForHome/HomeEntertainment/LCDTVs/Manuals/2014_TV_OM.pdf)
-- pages 58 through 59 in another
-  [sharp user manual](http://www.sharp.co.uk/cps/rde/xbcr/documents/documents/om/11_lcd-tv/LC40-46LE830E-RU-LE831E-RU_OM_GB.pdf)
-
-### To enable API on your TV
-
-1) MENU->Initial Setup->AQUOS Remote Control
-
-2) Enable
-
-3) Set Login/Pass
+Before installing this API, follow the instructions reported at
+https://sharp-aquos-remote-control.github.io/index.html#quick-start
 
 ## Installation and basic instructions
 
@@ -59,17 +49,18 @@ Full Documentation is available through pydoc
 
     pydoc sharp_aquos_rc
 
-## LICENSE
-
-MIT
-
 ## TODO/Contribute
 
 Contributions and Pull Requests always welcome.
 
 Currently on the TODO list:
-- Remote Button Functionality
 - Unit Tests
 - Error Checking and Input Validation
 - Better timeouts for sequential operations so that the sent 
   commands don't get ignored.
+- Documentation.
+
+## LICENSE
+
+MIT
+

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # sharp_aquos_rc
+
 ### Control Sharp Aquos SmartTVs with Python
+
 Based on the API for "Remote Control App" defined on pages 8-3 through 8-8 in the [sharp-user-manual].
 
 ### To enable API on your TV
+
 1) MENU->Initial Setup->AQUOS Remote Control
 
 2) Enable
@@ -10,11 +13,28 @@ Based on the API for "Remote Control App" defined on pages 8-3 through 8-8 in th
 3) Set Login/Pass
 
 ### Installation
-```
-pip install sharp_aquos_rc
-```
+
+    pip install sharp_aquos_rc
+
+### Command profiles
+
+Depending on the country of purchase of the television you must choose between
+one of the available profiles or command maps (see 
+the `./sharp_aquos_rc/commands` directory):
+
+- cn
+- eu
+- jp
+- us
+
+The `us` profile is used by default, so to choose another one simply pass it 
+as an option to the class constructor. For example:
+
+    >>> tv = sharp_aquos_rc.TV('192.168.1.5', 10002, 'admin', 'password', command_map='eu')
+
 
 ### Examples
+
 ```
 >>> import sharp_aquos_rc
 >>>
@@ -29,15 +49,17 @@ True
 ```
 
 ### Documentation
+
 Full Documentation is available through pydoc
-```
-pydoc sharp_aquos_rc
-```
+
+    pydoc sharp_aquos_rc
 
 ### LICENSE
+
 MIT
 
 ### TODO/Contribute
+
 Contributions and Pull Requests always welcome.
 
 Currently on the TODO list:
@@ -45,10 +67,6 @@ Currently on the TODO list:
 - Unit Tests
 - Error Checking and Input Validation
 
-
-
-
-
-[sharp-user-manual]: <http://files.sharpusa.com/Downloads/ForHome/HomeEntertainment/LCDTVs/Manuals/2014_TV_OM.pdf>
+[sharp-user-manual](http://files.sharpusa.com/Downloads/ForHome/HomeEntertainment/LCDTVs/Manuals/2014_TV_OM.pdf)
 
 

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ pip install sharp_aquos_rc
 >>> import sharp_aquos_rc
 >>>
 >>> tv = sharp_aquos_rc.TV('192.168.1.5', 10002, 'admin', 'password')
->>> 
+>>>
 >>> tv.power() # Returns 1 if TV is on and 0 if TV is off
 1
 >>> tv.power(0) # Turn the TV off
 True
->>> tv.input(2) # Set the TV to HDMI Input 2
+>>> tv.input('HDMI 2') # Set the TV to HDMI Input 2
 True
 ```
 
@@ -50,5 +50,3 @@ Currently on the TODO list:
 
 
 [sharp-user-manual]: <http://files.sharpusa.com/Downloads/ForHome/HomeEntertainment/LCDTVs/Manuals/2014_TV_OM.pdf>
-
-

--- a/demo.py
+++ b/demo.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+
+#
+# Copyright (c) 2017, Franco Masotti <franco.masotti@live.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import sharp_aquos_rc
+import time
+
+tv = sharp_aquos_rc.TV('192.168.1.5', 10002, 'admin', 'password', command_map='eu')
+
+# Turn on the tv and leave a timeout for the next operations.
+tv.power(1)
+time.sleep(10)
+# Set the volume to 0
+tv.volume(0)
+# Open the teletext
+tv.teletext(1)
+# Go to the specified page
+tv.teletext_jump(103)
+# Wait 60 seconds then turn off the tv.
+time.sleep(60)
+tv.power(0)

--- a/sharp_aquos_rc/commands/cn.yaml
+++ b/sharp_aquos_rc/commands/cn.yaml
@@ -20,43 +20,44 @@ channel_up: "CHUP1"
 channel_down: "CHDW1"
 teletext: "TEXT"
 teletext_jump: "DCPG"
+input_index: "IAVD?"
 input:
   tv:
     command: "ITVD0"
     name: "TV"
-    order: 0
+    index: 0
   hdmi_1:
     command: "IAVD1"
     name: "HDMI 1"
-    order: 1
+    index: 1
   hdmi_2:
     command: "IAVD2"
     name: "HDMI 2"
-    order: 2
+    index: 2
   hdmi_3:
     command: "IAVD3"
     name: "HDMI 3"
-    order: 3
+    index: 3
   hdmi_4:
     command: "IAVD4"
     name: "HDMI 4"
-    order: 4
+    index: 4
   component_in:
     command: "IAVD5"
     name: "Component"
-    order: 5
+    index: 5
   video_in_1:
     command: "IAVD6"
     name: "Video in 1"
-    order: 6
+    index: 6
   video_in_2:
     command: "IAVD7"
     name: "Video in 2"
-    order: 7
+    index: 7
   pc_in:
     command: "IAVD8"
     name: "PC"
-    order: 8
+    index: 8
 remote:
   0: "IRCO0127"
   1: "IRCO0101"

--- a/sharp_aquos_rc/commands/cn.yaml
+++ b/sharp_aquos_rc/commands/cn.yaml
@@ -18,6 +18,8 @@ digital_channel_cable_major: "DTVD"
 digital_channel_cable_minor: ""
 channel_up: "CHUP1"
 channel_down: "CHDW1"
+teletext: "TEXT"
+teletext_jump: "DCPG"
 input:
   tv:
     command: "ITVD0"

--- a/sharp_aquos_rc/commands/cn.yaml
+++ b/sharp_aquos_rc/commands/cn.yaml
@@ -18,43 +18,44 @@ digital_channel_cable_major: "DTVD"
 digital_channel_cable_minor: ""
 channel_up: "CHUP1"
 channel_down: "CHDW1"
+input_index: "IAVD?"
 input:
   tv:
     command: "ITVD0"
     name: "TV"
-    order: 0
+    index: 0
   hdmi_1:
     command: "IAVD1"
     name: "HDMI 1"
-    order: 1
+    index: 1
   hdmi_2:
     command: "IAVD2"
     name: "HDMI 2"
-    order: 2
+    index: 2
   hdmi_3:
     command: "IAVD3"
     name: "HDMI 3"
-    order: 3
+    index: 3
   hdmi_4:
     command: "IAVD4"
     name: "HDMI 4"
-    order: 4
+    index: 4
   component_in:
     command: "IAVD5"
     name: "Component"
-    order: 5
+    index: 5
   video_in_1:
     command: "IAVD6"
     name: "Video in 1"
-    order: 6
+    index: 6
   video_in_2:
     command: "IAVD7"
     name: "Video in 2"
-    order: 7
+    index: 7
   pc_in:
     command: "IAVD8"
     name: "PC"
-    order: 8
+    index: 8
 remote:
   0: "IRCO0127"
   1: "IRCO0101"

--- a/sharp_aquos_rc/commands/eu.yaml
+++ b/sharp_aquos_rc/commands/eu.yaml
@@ -18,6 +18,8 @@ digital_channel_cable_major: "DTVD"
 digital_channel_cable_minor: ""
 channel_up: "CHUP1"
 channel_down: "CHDW1"
+teletext: "TEXT"
+teletext_jump: "DCPG"
 input:
   tv: 
     command: "ITVD0"

--- a/sharp_aquos_rc/commands/eu.yaml
+++ b/sharp_aquos_rc/commands/eu.yaml
@@ -20,51 +20,44 @@ channel_up: "CHUP1"
 channel_down: "CHDW1"
 teletext: "TEXT"
 teletext_jump: "DCPG"
+input_index: "IAVD?"
 input:
-  tv: 
+  tv:
     command: "ITVD0"
     name: "TV"
-    order: 0
-  hdmi_1: 
-    command: "IRCO11F4"
-    name: "HDMI 1"
-    order: 1
-  hdmi_2: 
-    command: "IRCO11F5"
-    name: "HDMI 2"
-    order: 2
-  hdmi_3: 
-    command: "IRCO11F8"
-    name: "HDMI 3"
-    order: 3
-  hdmi_4: 
-    command: "IRCO1195"
-    name: "HDMI 4"
-    order: 4
-  component_in: 
+    index: 0
+  component_in:
     command: "IRCO11ED"
     name: "Component"
-    order: 5
-  video_in_1: 
+    index: 1
+  video_in_1:
     command: "IRCO11EE"
     name: "Video in 1"
-    order: 6
-  video_in_2: 
+    index: 2
+  video_in_2:
     command: "IRCO11EF"
     name: "Video in 2"
-    order: 7
-  pc_in: 
-    command: "IRC01197"
+    index: 3
+  hdmi_1:
+    command: "IRCO11F4"
+    name: "HDMI 1"
+    index: 4
+  hdmi_2:
+    command: "IRCO11F5"
+    name: "HDMI 2"
+    index: 5
+  hdmi_3:
+    command: "IRCO11F8"
+    name: "HDMI 3"
+    index: 6
+  hdmi_4:
+    command: "IRCO1195"
+    name: "HDMI 4"
+    index: 7
+  pc_in:
+    command: "IRCO1197"
     name: "PC"
-    order: 8
-  home_network: 
-    command: "IDIN0081"
-    name: "Home Network"
-    order: 9
-  usb_media: 
-    command: "IDIN0082"
-    name: "USB"
-    order: 10
+    index: 8
 remote:
   0: "IRCO010A"
   1: "IRCO0101"

--- a/sharp_aquos_rc/commands/eu.yaml
+++ b/sharp_aquos_rc/commands/eu.yaml
@@ -18,51 +18,44 @@ digital_channel_cable_major: "DTVD"
 digital_channel_cable_minor: ""
 channel_up: "CHUP1"
 channel_down: "CHDW1"
+input_index: "IAVD?"
 input:
-  tv: 
+  tv:
     command: "ITVD0"
     name: "TV"
-    order: 0
-  hdmi_1: 
-    command: "IRCO11F4"
-    name: "HDMI 1"
-    order: 1
-  hdmi_2: 
-    command: "IRCO11F5"
-    name: "HDMI 2"
-    order: 2
-  hdmi_3: 
-    command: "IRCO11F8"
-    name: "HDMI 3"
-    order: 3
-  hdmi_4: 
-    command: "IRCO1195"
-    name: "HDMI 4"
-    order: 4
-  component_in: 
+    index: 0
+  component_in:
     command: "IRCO11ED"
     name: "Component"
-    order: 5
-  video_in_1: 
+    index: 1
+  video_in_1:
     command: "IRCO11EE"
     name: "Video in 1"
-    order: 6
-  video_in_2: 
+    index: 2
+  video_in_2:
     command: "IRCO11EF"
     name: "Video in 2"
-    order: 7
-  pc_in: 
-    command: "IRC01197"
+    index: 3
+  hdmi_1:
+    command: "IRCO11F4"
+    name: "HDMI 1"
+    index: 4
+  hdmi_2:
+    command: "IRCO11F5"
+    name: "HDMI 2"
+    index: 5
+  hdmi_3:
+    command: "IRCO11F8"
+    name: "HDMI 3"
+    index: 6
+  hdmi_4:
+    command: "IRCO1195"
+    name: "HDMI 4"
+    index: 7
+  pc_in:
+    command: "IRCO1197"
     name: "PC"
-    order: 8
-  home_network: 
-    command: "IDIN0081"
-    name: "Home Network"
-    order: 9
-  usb_media: 
-    command: "IDIN0082"
-    name: "USB"
-    order: 10
+    index: 8
 remote:
   0: "IRCO010A"
   1: "IRCO0101"

--- a/sharp_aquos_rc/commands/jp.yaml
+++ b/sharp_aquos_rc/commands/jp.yaml
@@ -20,43 +20,44 @@ channel_up: "CHUP1"
 channel_down: "CHDW1"
 teletext: "TEXT"
 teletext_jump: "DCPG"
+input_index: "IAVD?"
 input:
   tv:
     command: "ITVD0"
     name: "TV"
-    order: 0
+    index: 0
   hdmi_1:
     command: "IAVD1"
     name: "HDMI 1"
-    order: 1
+    index: 1
   hdmi_2:
     command: "IAVD2"
     name: "HDMI 2"
-    order: 2
+    index: 2
   hdmi_3:
     command: "IAVD3"
     name: "HDMI 3"
-    order: 3
+    index: 3
   hdmi_4:
     command: "IAVD4"
     name: "HDMI 4"
-    order: 4
+    index: 4
   component_in:
     command: "IAVD5"
     name: "Component"
-    order: 5
+    index: 5
   video_in_1:
     command: "IAVD6"
     name: "Video in 1"
-    order: 6
+    index: 6
   video_in_2:
     command: "IAVD7"
     name: "Video in 2"
-    order: 7
+    index: 7
   pc_in:
     command: "IAVD8"
     name: "PC"
-    order: 8
+    index: 8
 remote:
   0: "IRCO0257"
   1: "IRCO024E"

--- a/sharp_aquos_rc/commands/jp.yaml
+++ b/sharp_aquos_rc/commands/jp.yaml
@@ -18,6 +18,8 @@ digital_channel_cable_major: "DTVD"
 digital_channel_cable_minor: ""
 channel_up: "CHUP1"
 channel_down: "CHDW1"
+teletext: "TEXT"
+teletext_jump: "DCPG"
 input:
   tv:
     command: "ITVD0"

--- a/sharp_aquos_rc/commands/jp.yaml
+++ b/sharp_aquos_rc/commands/jp.yaml
@@ -18,43 +18,44 @@ digital_channel_cable_major: "DTVD"
 digital_channel_cable_minor: ""
 channel_up: "CHUP1"
 channel_down: "CHDW1"
+input_index: "IAVD?"
 input:
   tv:
     command: "ITVD0"
     name: "TV"
-    order: 0
+    index: 0
   hdmi_1:
     command: "IAVD1"
     name: "HDMI 1"
-    order: 1
+    index: 1
   hdmi_2:
     command: "IAVD2"
     name: "HDMI 2"
-    order: 2
+    index: 2
   hdmi_3:
     command: "IAVD3"
     name: "HDMI 3"
-    order: 3
+    index: 3
   hdmi_4:
     command: "IAVD4"
     name: "HDMI 4"
-    order: 4
+    index: 4
   component_in:
     command: "IAVD5"
     name: "Component"
-    order: 5
+    index: 5
   video_in_1:
     command: "IAVD6"
     name: "Video in 1"
-    order: 6
+    index: 6
   video_in_2:
     command: "IAVD7"
     name: "Video in 2"
-    order: 7
+    index: 7
   pc_in:
     command: "IAVD8"
     name: "PC"
-    order: 8
+    index: 8
 remote:
   0: "IRCO0257"
   1: "IRCO024E"

--- a/sharp_aquos_rc/commands/us.yaml
+++ b/sharp_aquos_rc/commands/us.yaml
@@ -18,6 +18,8 @@ digital_channel_cable_major: "DC2U"
 digital_channel_cable_minor: "DC2L"
 channel_up: "CHUP1"
 channel_down: "CHDW1"
+teletext: "TEXT"
+teletext_jump: "DCPG"
 input:
   tv:
     command: "ITVD0"

--- a/sharp_aquos_rc/commands/us.yaml
+++ b/sharp_aquos_rc/commands/us.yaml
@@ -20,43 +20,44 @@ channel_up: "CHUP1"
 channel_down: "CHDW1"
 teletext: "TEXT"
 teletext_jump: "DCPG"
+input_index: "IAVD?"
 input:
   tv:
     command: "ITVD0"
     name: "TV"
-    order: 0
+    index: 0
   hdmi_1:
     command: "IAVD1"
     name: "HDMI 1"
-    order: 1
+    index: 1
   hdmi_2:
     command: "IAVD2"
     name: "HDMI 2"
-    order: 2
+    index: 2
   hdmi_3:
     command: "IAVD3"
     name: "HDMI 3"
-    order: 3
+    index: 3
   hdmi_4:
     command: "IAVD4"
     name: "HDMI 4"
-    order: 4
+    index: 4
   component_in:
     command: "IAVD5"
     name: "Component"
-    order: 5
+    index: 5
   video_in_1:
     command: "IAVD6"
     name: "Video in 1"
-    order: 6
+    index: 6
   video_in_2:
     command: "IAVD7"
     name: "Video in 2"
-    order: 7
+    index: 7
   pc_in:
     command: "IAVD8"
     name: "PC"
-    order: 8
+    index: 8
 remote:
   0: "RCKY0000"
   1: "RCKY0001"

--- a/sharp_aquos_rc/commands/us.yaml
+++ b/sharp_aquos_rc/commands/us.yaml
@@ -18,43 +18,44 @@ digital_channel_cable_major: "DC2U"
 digital_channel_cable_minor: "DC2L"
 channel_up: "CHUP1"
 channel_down: "CHDW1"
+input_index: "IAVD?"
 input:
   tv:
     command: "ITVD0"
     name: "TV"
-    order: 0
+    index: 0
   hdmi_1:
     command: "IAVD1"
     name: "HDMI 1"
-    order: 1
+    index: 1
   hdmi_2:
     command: "IAVD2"
     name: "HDMI 2"
-    order: 2
+    index: 2
   hdmi_3:
     command: "IAVD3"
     name: "HDMI 3"
-    order: 3
+    index: 3
   hdmi_4:
     command: "IAVD4"
     name: "HDMI 4"
-    order: 4
+    index: 4
   component_in:
     command: "IAVD5"
     name: "Component"
-    order: 5
+    index: 5
   video_in_1:
     command: "IAVD6"
     name: "Video in 1"
-    order: 6
+    index: 6
   video_in_2:
     command: "IAVD7"
     name: "Video in 2"
-    order: 7
+    index: 7
   pc_in:
     command: "IAVD8"
     name: "PC"
-    order: 8
+    index: 8
 remote:
   0: "RCKY0000"
   1: "RCKY0001"

--- a/sharp_aquos_rc/tv.py
+++ b/sharp_aquos_rc/tv.py
@@ -16,10 +16,20 @@ class TV(object):
 
     URL: http://github.com/jmoore/sharp_aquos_rc
     """
+
     _VALID_COMMAND_MAPS = ["eu", "us", "cn", "jp"]
 
     def __init__(self, ip, port, username, password,  # pylint: disable=R0913
                  timeout=5, connection_timeout=2, command_map='us'):
+
+        assert isinstance(ip, str)
+        assert isinstance(port, int)
+        assert isinstance(username, str)
+        assert isinstance(password, str)
+        assert isinstance(timeout, int)
+        assert isinstance(connection_timeout, int)
+        assert isinstance(command_map, str)
+
         self.ip_address = ip
         self.port = port
         self.auth = str.encode(username + '\r' + password + '\r')

--- a/sharp_aquos_rc/tv.py
+++ b/sharp_aquos_rc/tv.py
@@ -444,14 +444,14 @@ class TV(object):
         Description:
             Change the Channel +1
         """
-        self._send_command('digital_channel_up')
+        self._send_command('channel_up')
 
     def channel_down(self):
         """
         Description:
             Change the Channel -1
         """
-        self._send_command('digital_channel_down')
+        self._send_command('channel_down')
 
     def get_remote_button_list(self):
         """

--- a/sharp_aquos_rc/tv.py
+++ b/sharp_aquos_rc/tv.py
@@ -239,6 +239,31 @@ class TV(object):
         """
         return self._send_command('volume_down')
 
+    def teletext(self, opt='?'):
+        """
+        Description:
+
+            Enable the teletext
+            Call with no arguments to get current setting
+
+        Arguments:
+            opt: integer
+                0: Disable
+                1: Enable
+        """
+        return self._send_command('teletext', opt)
+
+    def teletext_jump(self, opt='100'):
+        """
+        Description:
+            Jump to specified page
+
+        Arguments:
+            opt: integer
+            100 - 899: Page number
+        """
+        return self._send_command('teletext_jump', opt)
+
     def view_mode(self, opt='?'):
         """
         Description:

--- a/sharp_aquos_rc/tv.py
+++ b/sharp_aquos_rc/tv.py
@@ -165,10 +165,10 @@ class TV(object):
         """
         inputs = [' '] * len(self.command['input'])
         for key in self.command['input']:
-            inputs[self.command['input'][key]['order']] = {"key":key, "name":self.command['input'][key]['name']}
+            inputs[self.command['input'][key]['index']] = {"key":key, "name":self.command['input'][key]['name']}
         return inputs
 
-    def input(self, opt):
+    def input(self, opt='?'):
         """
         Description:
 
@@ -179,11 +179,16 @@ class TV(object):
             opt: string
                 Name provided from input list or key from yaml ("HDMI 1" or "hdmi_1")
         """
-
-        for key in self.command['input']:
-            if (key == opt) or (self.command['input'][key]['name'] == opt):
-                return self._send_command(['input', key, 'command'])
-        return False
+        if opt == '?':
+            index = self._send_command('input_index')
+            for key in self.command['input']:
+                if (self.command['input'][key]['index'] == index):
+                    return self.command['input'][key]['name']
+        else:
+            for key in self.command['input']:
+                if (key == opt) or (self.command['input'][key]['name'] == opt):
+                    return self._send_command(['input', key, 'command'])
+            return False
 
     def av_mode(self, opt='?'):
         """
@@ -408,4 +413,4 @@ class TV(object):
             opt: string
                 key provided from input list
         """
-        return self._send_command("remote", opt)
+        return self._send_command(['remote', opt])


### PR DESCRIPTION
See page 61 of 85 for the teletext commands:
http://www.sharp.co.uk/cps/rde/xbcr/documents/documents/om/11_lcd-tv/LC40-46LE830E-RU-LE831E-RU_OM_GB.pdf

The commands I've added have only been tested on the `eu` profile. I have no idea if they work for the other three.
As you can see I have put

    teletext: "TEXT"
    telexext_jump: "DCPG"

in all command maps, hoping that this does not break anything.
