### PR TITLE
Fix license classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,7 @@ setup(
     url = 'https://github.com/jmoore987/sharp_aquos_rc',
     download_url = 'https://github.com/jmoore987/sharp_aquos_rc/tarball/0.4',
     keywords = ['sharp', 'aquos', 'remote', 'control', 'tv', 'smarttv', 'iot' ],
-    classifiers = []
+    classifiers = [
+        'License :: OSI Approved :: MIT License'
+    ]
 )


### PR DESCRIPTION
Hey 👋🏻,

I am currently looking into licensing at Home Assistant, and I found that we could not detect the license of this library properly. According to pyproject.toml documentation about the `license` field:
> If you are using a standard, well-known license, it is not necessary to use this field. Instead, you should use one of the [classifiers](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#classifiers) starting with License ::. (As a general rule, it is a good idea to use a standard, well-known license, both to avoid confusion and because some organizations avoid software whose license is unapproved.)

If you could do a release after this PR, that would be awesome :)